### PR TITLE
Don't build venvs with `--system-site-packages`

### DIFF
--- a/buildkit/internal/transform/transforms.go
+++ b/buildkit/internal/transform/transforms.go
@@ -3,12 +3,13 @@ package transform
 import (
 	"bytes"
 	"fmt"
-	"github.com/astronomer/astro-runtime-frontend/internal/dockerfile"
-	"github.com/docker/distribution/reference"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/astronomer/astro-runtime-frontend/internal/dockerfile"
+	"github.com/docker/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
 const (
@@ -25,7 +26,7 @@ USER astro
 `
 	virtualEnvTemplate = `RUN mkdir -p /home/astro/.venv/{{.Name}}
 {{if .RequirementsFile}}COPY {{.RequirementsFile}} /home/astro/.venv/{{.Name}}/requirements.txt{{end}}
-RUN /usr/local/bin/python{{.PythonMajorMinor}} -m venv --system-site-packages /home/astro/.venv/{{.Name}}
+RUN /usr/local/bin/python{{.PythonMajorMinor}} -m venv /home/astro/.venv/{{.Name}}
 ENV ASTRO_PYENV_{{.Name}} /home/astro/.venv/{{.Name}}/bin/python
 {{if .RequirementsFile}}RUN --mount=type=cache,target=/home/astro/.cache/pip /home/astro/.venv/{{.Name}}/bin/pip --cache-dir=/home/astro/.cache/pip install -r /home/astro/.venv/{{.Name}}/requirements.txt{{end}}
 `

--- a/buildkit/internal/transform/transforms_test.go
+++ b/buildkit/internal/transform/transforms_test.go
@@ -32,7 +32,7 @@ RUN ln -s /usr/local/include/python3.8 /usr/local/include/python3.8m
 USER astro
 RUN mkdir -p /home/astro/.venv/venv1
 COPY reqs/venv1.txt /home/astro/.venv/venv1/requirements.txt
-RUN /usr/local/bin/python3.8 -m venv --system-site-packages /home/astro/.venv/venv1
+RUN /usr/local/bin/python3.8 -m venv /home/astro/.venv/venv1
 ENV ASTRO_PYENV_venv1 /home/astro/.venv/venv1/bin/python
 RUN --mount=type=cache,target=/home/astro/.cache/pip /home/astro/.venv/venv1/bin/pip --cache-dir=/home/astro/.cache/pip install -r /home/astro/.venv/venv1/requirements.txt
 COPY foo bar
@@ -48,7 +48,7 @@ RUN ln -s /usr/local/include/python3.10 /usr/local/include/python3.10m
 USER astro
 RUN mkdir -p /home/astro/.venv/venv2
 
-RUN /usr/local/bin/python3.10 -m venv --system-site-packages /home/astro/.venv/venv2
+RUN /usr/local/bin/python3.10 -m venv /home/astro/.venv/venv2
 ENV ASTRO_PYENV_venv2 /home/astro/.venv/venv2/bin/python
 RUN mkdir /tmp/bar
 `


### PR DESCRIPTION
While it might take longer to build without it, but otherwise we end up
with "version hell" as for anything running in Python 3.9
