### PR TITLE
Update README.md with complete Dockerfile example in Gory Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The `# syntax` line tells buildkit to user our Build frontend to process the Doc
 The example Dockerfile above gets converted into roughly the following Dockerfile:
 
 ```Dockerfile
-# syntax=quay.io/astronomer/airflow-extensions:v1
+# syntax=docker/dockerfile:1
 
 FROM quay.io/astronomer/astro-runtime:7.2.0
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,13 @@ This contains an Apache Airflow provider that providers the `@task.venv` decorat
 
 The `# syntax` line tells buildkit to user our Build frontend to process the Dockerfile into instructions.
 
-The example Dockerfile above gets converted into roughly following instructions
+The example Dockerfile above gets converted into roughly the following Dockerfile:
 
 ```Dockerfile
+# syntax=quay.io/astronomer/airflow-extensions:v1
+
+FROM quay.io/astronomer/astro-runtime:7.2.0
+
 USER root
 COPY --link --from=python:3.8-slim /usr/local/bin/*3.8* /usr/local/bin/
 COPY --link --from=python:3.8-slim /usr/local/include/python3.8* /usr/local/include/python3.8


### PR DESCRIPTION
The existing "The Gory Details" section omits a couple lines of what would be a complete Dockerfile. As someone unfamiliar with `# syntax = ...`, I thought that part was totally separate and unnecessary if I was doing the whole thing "from scratch", leading to errors.