### PR TITLE
Use the right python image dist for building images

### DIFF
--- a/buildkit/internal/transform/transforms.go
+++ b/buildkit/internal/transform/transforms.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	pythonEnvTemplate = `USER root
-COPY --link --from=python:{{.PythonVersion}}-slim /usr/local/bin/*{{.PythonMajorMinor}}* /usr/local/bin/
-COPY --link --from=python:{{.PythonVersion}}-slim /usr/local/include/python{{.PythonMajorMinor}}* /usr/local/include/python{{.PythonMajorMinor}}
-COPY --link --from=python:{{.PythonVersion}}-slim /usr/local/lib/pkgconfig/*{{.PythonMajorMinor}}* /usr/local/lib/pkgconfig/
-COPY --link --from=python:{{.PythonVersion}}-slim /usr/local/lib/*{{.PythonMajorMinor}}*.so* /usr/local/lib/
-COPY --link --from=python:{{.PythonVersion}}-slim /usr/local/lib/python{{.PythonMajorMinor}} /usr/local/lib/python{{.PythonMajorMinor}}
+COPY --link --from=python:{{.PythonVersion}}-{{.PythonFlavour}} /usr/local/bin/*{{.PythonMajorMinor}}* /usr/local/bin/
+COPY --link --from=python:{{.PythonVersion}}-{{.PythonFlavour}} /usr/local/include/python{{.PythonMajorMinor}}* /usr/local/include/python{{.PythonMajorMinor}}
+COPY --link --from=python:{{.PythonVersion}}-{{.PythonFlavour}} /usr/local/lib/pkgconfig/*{{.PythonMajorMinor}}* /usr/local/lib/pkgconfig/
+COPY --link --from=python:{{.PythonVersion}}-{{.PythonFlavour}} /usr/local/lib/*{{.PythonMajorMinor}}*.so* /usr/local/lib/
+COPY --link --from=python:{{.PythonVersion}}-{{.PythonFlavour}} /usr/local/lib/python{{.PythonMajorMinor}} /usr/local/lib/python{{.PythonMajorMinor}}
 RUN /sbin/ldconfig /usr/local/lib
 # hack for python <= 3.7
 RUN ln -s /usr/local/include/python{{.PythonMajorMinor}} /usr/local/include/python{{.PythonMajorMinor}}m
@@ -36,6 +36,8 @@ ENV ASTRO_PYENV_{{.Name}} /home/astro/.venv/{{.Name}}/bin/python
 	argCommand        = "ARG"
 	pyenvCommand      = "PYENV"
 	astroRuntimeImage = "quay.io/astronomer/astro-runtime"
+
+	defaultImageFlavour = "slim-bullseye"
 )
 
 var (
@@ -51,6 +53,7 @@ type Transformer struct {
 type virtualEnv struct {
 	Name             string
 	PythonVersion    string
+	PythonFlavour    string
 	PythonMajorMinor string
 	RequirementsFile string
 }
@@ -167,6 +170,8 @@ func parsePyenvDirective(s string) (*virtualEnv, error) {
 	}
 	env := &virtualEnv{
 		PythonVersion: tokens[1],
+		// For now we just hardcode this -- will add an option later
+		PythonFlavour: defaultImageFlavour,
 		Name:          tokens[2],
 	}
 	if len(tokens) > 3 {

--- a/buildkit/internal/transform/transforms_test.go
+++ b/buildkit/internal/transform/transforms_test.go
@@ -22,11 +22,11 @@ ARG baseimage
 FROM ${baseimage}
 `
 	expectedDockerfile := `USER root
-COPY --link --from=python:3.8-slim /usr/local/bin/*3.8* /usr/local/bin/
-COPY --link --from=python:3.8-slim /usr/local/include/python3.8* /usr/local/include/python3.8
-COPY --link --from=python:3.8-slim /usr/local/lib/pkgconfig/*3.8* /usr/local/lib/pkgconfig/
-COPY --link --from=python:3.8-slim /usr/local/lib/*3.8*.so* /usr/local/lib/
-COPY --link --from=python:3.8-slim /usr/local/lib/python3.8 /usr/local/lib/python3.8
+COPY --link --from=python:3.8-slim-bullseye /usr/local/bin/*3.8* /usr/local/bin/
+COPY --link --from=python:3.8-slim-bullseye /usr/local/include/python3.8* /usr/local/include/python3.8
+COPY --link --from=python:3.8-slim-bullseye /usr/local/lib/pkgconfig/*3.8* /usr/local/lib/pkgconfig/
+COPY --link --from=python:3.8-slim-bullseye /usr/local/lib/*3.8*.so* /usr/local/lib/
+COPY --link --from=python:3.8-slim-bullseye /usr/local/lib/python3.8 /usr/local/lib/python3.8
 RUN /sbin/ldconfig /usr/local/lib
 
 RUN ln -s /usr/local/include/python3.8 /usr/local/include/python3.8m
@@ -38,11 +38,11 @@ ENV ASTRO_PYENV_venv1 /home/astro/.venv/venv1/bin/python
 RUN --mount=type=cache,target=/home/astro/.cache/pip /home/astro/.venv/venv1/bin/pip --cache-dir=/home/astro/.cache/pip install -r /home/astro/.venv/venv1/requirements.txt
 COPY foo bar
 USER root
-COPY --link --from=python:3.10-slim /usr/local/bin/*3.10* /usr/local/bin/
-COPY --link --from=python:3.10-slim /usr/local/include/python3.10* /usr/local/include/python3.10
-COPY --link --from=python:3.10-slim /usr/local/lib/pkgconfig/*3.10* /usr/local/lib/pkgconfig/
-COPY --link --from=python:3.10-slim /usr/local/lib/*3.10*.so* /usr/local/lib/
-COPY --link --from=python:3.10-slim /usr/local/lib/python3.10 /usr/local/lib/python3.10
+COPY --link --from=python:3.10-slim-bullseye /usr/local/bin/*3.10* /usr/local/bin/
+COPY --link --from=python:3.10-slim-bullseye /usr/local/include/python3.10* /usr/local/include/python3.10
+COPY --link --from=python:3.10-slim-bullseye /usr/local/lib/pkgconfig/*3.10* /usr/local/lib/pkgconfig/
+COPY --link --from=python:3.10-slim-bullseye /usr/local/lib/*3.10*.so* /usr/local/lib/
+COPY --link --from=python:3.10-slim-bullseye /usr/local/lib/python3.10 /usr/local/lib/python3.10
 RUN /sbin/ldconfig /usr/local/lib
 
 RUN ln -s /usr/local/include/python3.10 /usr/local/include/python3.10m


### PR DESCRIPTION
Right now the Astro Runtime images all use the `python:3.x-slim-bullseye`
variant -- and we need to match it otherwise the python we copy in is linked
against a different glibc and will not run.

Closes #17
