### PR TITLE
Update README.md clarifying the DOCKER_BUILDKIT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,7 @@ def snowpark_task():
 
 ## Requirements for building Docker images
 
-This needs the [buildkit](https://docs.docker.com/build/buildkit/) backend for Docker.
-
-It is enabled by default for Docker Desktop users; Linux users will need to enable it:
+This provider needs the [buildkit](https://docs.docker.com/build/buildkit/) backend for Docker. BuildKit is enabled for DockerDesktop users by default. In other environments (e.g. Linux or CI/CD pipelines), BuildKit can be enabled by setting the environment variable `DOCKER_BUILDKIT=1`. 
 
 To set the BuildKit environment variable when running the docker build command, run:
 


### PR DESCRIPTION
I wanted to specifically call out setting the env var in ci/cd pipelines, as DOCKER_BUILDKIT is not enabled for GitHub Actions by default, which was giving me trouble.